### PR TITLE
Makes ssl-expiry-date compatible with BSD tools (mktemp and make)

### DIFF
--- a/ssl-expiry-date
+++ b/ssl-expiry-date
@@ -42,7 +42,14 @@ fi
 #
 #  Make a temporary file
 #
-tmp=$(mktemp)
+# Test if we have BSD or GNU version of mktemp
+if ( strings $(which mktemp) | grep -q GNU); then
+   #We have the GNU version
+   tmp=$(mktemp)
+else
+  #We have the BSD version
+   tmp=$(mktemp -t tmp)
+fi
 
 
 #
@@ -68,7 +75,21 @@ rm -f "$tmp"
 #
 #  Convert the expiry date + todays date to seconds-past epoch
 #
-then=$(date --date="$date" +%s)
+# Check if we have the BSD or the GNU version of date
+if (strings $(which date) | grep -q GNU); then
+  # We have GNU this is easy
+  then=$(date --date "$date" +%s)
+else
+  # We have BSD now it is getting complicated
+  year=$(echo $date | awk '{print $4}')
+  month=$(echo $date | awk '{print $1}')
+  day=$(echo $date | awk '{print $2}')
+  hour=$(echo $date | awk '{print $3}' | awk -F: '{print $1}')
+  minute=$(echo $date | awk '{print $3}' | awk -F: '{print $2}')
+  second=$(echo $date | awk '{print $3}' | awk -F: '{print $3}')
+  then=$(date -v${year}y -v${month} -v${day}d -v${hour}H -v${minute}M -v${second}S -u +%s)
+fi
+
 now=$(date +%s)
 
 #


### PR DESCRIPTION
On BSD flavored UNIXes mktemp and date behave differently, this pull request solves that.
- on BSD's mktemp a prefix or template is mandatory while n GNU's mktemp its not and the template defaults to tmp 
- on BSD's date the --date parameter doesn't exist but it uses -v instead for that purpose (with a more complicated syntax)
