### PR TITLE
Add plugin loader script for antigen, oh-my-zsh et al

### DIFF
--- a/sysadmin-util.plugin.zsh
+++ b/sysadmin-util.plugin.zsh
@@ -1,0 +1,8 @@
+#
+# This makes the sysadmin-utils more easily used with antigen,
+# oh-my-zsh, and any other framework that understands their
+# plugin structure.
+#
+# Add our plugin's root diretory to user's path
+PLUGIN_D="$(dirname $0)"
+export PATH=${PATH}:${PLUGIN_D}


### PR DESCRIPTION
This makes using the sysadmin-util scripts repo plugin compatible so it's easier to use with ZSH frameworks like antigen and oh-my-zsh. For antigen in particular, adding them to your environment is simplified down to adding `antigen plugin skx/syadmin-util` to .zshrc, and antigen will then take care of cloning the repo and adding it to $PATH. This makes it a lot easier to keep tools in sync across multiple machines.
