### PR TITLE
fix illegal bytestream error from tr on OSX

### DIFF
--- a/randpass
+++ b/randpass
@@ -56,5 +56,5 @@ done
 #
 #  Output the password
 #
-printf "%s\n" $(cat /dev/urandom | tr -cd "$cset" | head -c $len )
+printf "%s\n" $(cat /dev/urandom | env LC_CTYPE=C tr -cd "$cset" | head -c $len )
 


### PR DESCRIPTION
Out of the box, randpass on OSX 10.10-Yosemite throws
  
$ ./randpass
tr: Illegal byte sequence


This commit fixes it minimally.